### PR TITLE
Set special_price to product via catalog-staging, if exists.

### DIFF
--- a/Model/ProductDataMapper.php
+++ b/Model/ProductDataMapper.php
@@ -141,15 +141,15 @@ class ProductDataMapper
     private function validatePricePayload(SpecialPriceInterface $price)
     {
         if (
-            $price->getPrice() ||
-            $price->getStoreId() ||
-            $price->getSku() ||
-            $price->getPriceFrom() ||
-            $price->getPriceTo()
+            !$price->getPrice() ||
+            !$price->getStoreId() ||
+            !$price->getSku() ||
+            !$price->getPriceFrom() ||
+            !$price->getPriceTo()
         ) {
-            return true;
+            return false;
         }
 
-        return false;
+        return true;
     }
 }

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -6,4 +6,8 @@
     <extension_attributes for="Magento\ConfigurableProduct\Api\Data\OptionInterface">
         <attribute code="attribute_code" type="string" />
     </extension_attributes>
+
+    <extension_attributes for="Magento\Catalog\Api\Data\ProductInterface">
+        <attribute code="special_price" type="Magento\Catalog\Api\Data\SpecialPriceInterface[]" />
+    </extension_attributes>
 </config>


### PR DESCRIPTION
Set special price to product from extension attribute
-----------------

Extension attribute payload for `rest/V1/products-with-option-codes/SKU-HERE` with special price info: 

```
            "extension_attributes": {
                "special_price": [{
			    	"price": "7.65",
			    	"store_id": "1",
				    "sku": "BMP124",
				    "price_from": "2018-12-04 13:48:05",
				    "price_to": "2018-12-07 00:00:00"
                },{
			    	"price": "10.65",
			    	"store_id": "1",
				    "sku": "BMP124",
				    "price_from": "2018-12-12 13:48:05",
				    "price_to": "2018-12-19 00:00:00"
                }]
            },
```

**Results (At the top of admin product edit page):**

![image](https://user-images.githubusercontent.com/22290866/47798053-7d41f780-dd1f-11e8-97bd-3c3118a532d5.png)