### PR TITLE
Add Magento 2.3.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,14 @@ addons:
       - mysql-client-5.6
   hosts:
       - magento2.travis
+services:
+  - rabbitmq
+  - elasticsearch
 language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
 env:
   global:
     - COMPOSER_BIN_DIR=~/bin
@@ -22,22 +26,26 @@ env:
     - MAGENTO_VERSION=2.1
     - MAGENTO_VERSION=2.2-develop
     - MAGENTO_VERSION=2.2
-    - MAGENTO_VERSION=2.2 CODE_COVERAGE=1
     - MAGENTO_VERSION=2.3-develop
+    - MAGENTO_VERSION=2.3 CODE_COVERAGE=1
 matrix:
   allow_failures:
     - env: MAGENTO_VERSION=2.1-develop
     - env: MAGENTO_VERSION=2.2-develop
     - env: MAGENTO_VERSION=2.3-develop
   exclude:
-    - php: 7.1
+    - php: 7.2
       env: MAGENTO_VERSION=2.1-develop
-    - php: 7.1
+    - php: 7.2
       env: MAGENTO_VERSION=2.1
-    - php: 7.0
-      env: MAGENTO_VERSION=2.2 CODE_COVERAGE=1
-    - php: 7.1
+    - php: 7.2
+      env: MAGENTO_VERSION=2.2-develop
+    - php: 7.2
       env: MAGENTO_VERSION=2.2
+    - php: 7.0
+      env: MAGENTO_VERSION=2.3-develop
+    - php: 7.0
+      env: MAGENTO_VERSION=2.3 CODE_COVERAGE=1
 cache:
   apt: true
   directories: $HOME/.composer/cache

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": ">=7",
-        "magento/framework": "^100|^101",
-        "magento/module-catalog": "^101|^102",
-        "magento/module-eav": "^100|^101",
+        "magento/framework": "^100|^101|^102",
+        "magento/module-catalog": "^101|^102|^103",
+        "magento/module-eav": "^100|^101|^102",
         "magento/module-configurable-product": "^100"
     },
     "require-dev": {


### PR DESCRIPTION
### Description
This PR updates the composer version constraints to support Magento 2.3.1. This also adds support for a Magento 2.3 integration test in Travis. Previously this was run against 2.3-develop and would not matter if it failed